### PR TITLE
New curve

### DIFF
--- a/server/util/scores.ts
+++ b/server/util/scores.ts
@@ -1,13 +1,17 @@
-const p0 = 0.7
-const p1 = 0.96
-
-const c0 = -Math.atanh(p0)
-const c1 = Math.atanh(p1)
-const a = (x: number): number => (1 - Math.tanh(x)) / 2
-const b = (x: number): number => (a((c1 - c0) * x + c0) - a(c1)) / (a(c0) - a(c1))
-
+// rl is min challenge points
+// rh is max challenge points
+// maxSolves is usually 800 and honestly after that point it doesn't matter too much
+// solves is number of solves chall has
+//
+// formula im using (one curve for hard challs, one curve for easy challs:
+// min(max(428 * (0.995) ** solves + 75, 428 * (0.9978) ** solves, 100), 500)
+//
+// put below into desmos to see curve:
+// y_{2}=428\left(.995\right)^{x}+75
+// y_{3}=428\left(.9978\right)^{x}
+// y=\min\left(\max\left(y_{2},\ y_{3},\ 100\right),\ 500\right)
 export const getScore = (rl: number, rh: number, maxSolves: number, solves: number): number => {
-  const s = Math.max(1, maxSolves)
-  const f = (x: number): number => rl + (rh - rl) * b(x / s)
-  return Math.round(Math.max(f(solves), f(s)))
+  const hardCurve = 428 * (0.995) ** solves + 75;
+  const easyCurve = 428 * (0.9978) ** solves;
+  return Math.min(Math.max(hardCurve, easyCurve, rl), rh);
 }

--- a/server/util/scores.ts
+++ b/server/util/scores.ts
@@ -13,5 +13,6 @@
 export const getScore = (rl: number, rh: number, maxSolves: number, solves: number): number => {
   const hardCurve = 428 * (0.995) ** solves + 75;
   const easyCurve = 428 * (0.9978) ** solves;
-  return Math.round(Math.min(Math.max(hardCurve, easyCurve, rl), rh));
+  const veryEasyCurve = -0.055 * solves + 150;
+  return Math.round(Math.min(Math.max(hardCurve, easyCurve, veryEasyCurve, rl), rh));
 }

--- a/server/util/scores.ts
+++ b/server/util/scores.ts
@@ -13,5 +13,5 @@
 export const getScore = (rl: number, rh: number, maxSolves: number, solves: number): number => {
   const hardCurve = 428 * (0.995) ** solves + 75;
   const easyCurve = 428 * (0.9978) ** solves;
-  return Math.min(Math.max(hardCurve, easyCurve, rl), rh);
+  return Math.round(Math.min(Math.max(hardCurve, easyCurve, rl), rh));
 }


### PR DESCRIPTION
Sets curve to `min(max(428 * (0.995) ** solves + 75, 428 * (0.9978) ** solves, 100), 500)`

This has values of (last argument to `getScore` is number of solves):
```
> getScore(100, 500, 800, 1)
500
> getScore(100, 500, 800, 5)
492
> getScore(100, 500, 800, 10)
482
> getScore(100, 500, 800, 20)
462
> getScore(100, 500, 800, 50)
408
> getScore(100, 500, 800, 100)
343
> getScore(100, 500, 800, 200)
276
> getScore(100, 500, 800, 300)
221
> getScore(100, 500, 800, 400)
177
> getScore(100, 500, 800, 500)
142
> getScore(100, 500, 800, 600)
114
```

![plot](https://github.com/user-attachments/assets/7c0b9ff5-ec2b-4336-b944-9531a90651d1)

This new curve will help differentiate between the most difficult challenges for the top few teams while still keeping the challenges most people (ucla students, other beginners, etc.) solve at a fun point level.